### PR TITLE
No arrow CFLAGS can be perfectly valid

### DIFF
--- a/configure
+++ b/configure
@@ -96,7 +96,7 @@ else
     PKGCONFIG_DIRS=`pkg-config --libs-only-L --silence-errors ${PKG_CONFIG_NAME}`
   fi
 
-  if [ "$PKGCONFIG_CFLAGS" ] && [ "$PKGCONFIG_LIBS" ]; then
+  if [ "$PKGCONFIG_CFLAGS" ] || [ "$PKGCONFIG_LIBS" ]; then
     FOUND_LIB_DIR=`echo $PKG_DIRS | sed -e 's/^-L//'`
     echo "*** Arrow C++ libraries found via pkg-config at $FOUND_LIB_DIR"
     PKG_CFLAGS="$PKGCONFIG_CFLAGS"


### PR DESCRIPTION
On the Canadian HPC clusters, for example,
```
[tyson@gra-login3 ~]$ module load gcc thrift arrow
[tyson@gra-login3 ~]$ pkg-config --cflags arrow

[tyson@gra-login3 ~]$ pkg-config --libs arrow
-L/cvmfs/soft.computecanada.ca/easybuild/software/2020/avx2/Compiler/gcc9/arrow/10.0.1/lib -larrow
[tyson@gra-login3 ~]$ 
```
Without this it insists on building the underlying arrow library instead of using the system one (which is not a good thing the system one is a fully optimized version built by the staff for the cluster). 